### PR TITLE
Update the maximum value for color temperature

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ instance.prototype.actions = function(system) {
 				label: 'Color Temperature',
 				id: 'temp',
 				min: 143,
-				max: 334,
+				max: 344,
 				default: 143,
 				required: true,
 				range: true


### PR DESCRIPTION
Looks like the upper bounds for a 2900k color temperature is 344. 

Two ways of confirming this:
* Messed with the Elgato app and read it back by doing a GET on curl http://IP:9123/elgato/lights
* Confirmed the value in another Elgato package: https://github.com/derjayjay/homebridge-keylights/blob/master/src/keyLightsAccessory.ts#L48