### PR TITLE
Fixing category

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"keywords": [
-		"lighting"
+		"Lighting"
 	],
 	"author": "David Stevens <issues@jtf4.com>",
 	"license": "MIT"


### PR DESCRIPTION
The "Add by category" feature of Companion seems case sensitive, today there is a "Lighting" and "lighting" categories (with only keylight in the former), this change should merge them.