### PR TITLE
Fixing: polling not working after upgrade (issue #9)

### DIFF
--- a/src/configs.js
+++ b/src/configs.js
@@ -24,7 +24,7 @@ module.exports = {
 				id: 'polling',
 				label: 'Enable Polling?',
 				width: 6,
-				default: true,
+				default: false,
 			},
 			{
 				type: 'number',


### PR DESCRIPTION
Fixes reported issue (#9) in which polling is not working upon upgrading from `v2.1.1` to `v.2.0.0`.

There are two possible fixes:
- create an upgrade script to set the default config
- set the default `polling` config to `false` 

I opted for the latter so we don't opt upgrading users into polling automatically upon upgrading.