### PR TITLE
Run CI on newer node to fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
While this doesn't fix the CI, as it looks like prettier needs running, it at least correctly reports that state rather than failing to complete...